### PR TITLE
feat: Q&A 게시물 삭제 구현, 마이페이지 게시글 모아보기 구현

### DIFF
--- a/src/constants/posts.ts
+++ b/src/constants/posts.ts
@@ -16,6 +16,7 @@ export interface Post {
   title: string;
   content: string;
   author: string;
+  email: string;
   createdAt: string;
   answered: boolean;
   counts: Counts;

--- a/src/pages/MyPage/Posts.tsx
+++ b/src/pages/MyPage/Posts.tsx
@@ -1,8 +1,11 @@
 import React, { useState } from 'react';
-import { getPosts } from '../../utils/postStorage';
+import { getPosts, getPostsByEmail } from '../../utils/postStorage';
 import { Post } from '../../constants/posts';
 import PostList from '../../components/PostList';
 import { useNavigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../hoc/store';
+import icon_logo from '../../assets/img/icon_logo.png';
 
 const Posts: React.FC = () => {
   const [currentPage, setCurrentPage] = useState(1);
@@ -10,8 +13,9 @@ const Posts: React.FC = () => {
   const postsPerPage = 5;
   const indexOfLastPost = currentPage * postsPerPage;
   const indexOfFirstPost = indexOfLastPost - postsPerPage;
+  const userEmail = useSelector((state: RootState) => state.auth.userEmail);
 
-  const posts: Post[] = getPosts();
+  const posts: Post[] = getPostsByEmail(userEmail);
   // userId == loggedUserId인 post 필터링
   const currentPosts = posts.slice(indexOfFirstPost, indexOfLastPost);
 
@@ -34,15 +38,21 @@ const Posts: React.FC = () => {
       >
         게시글
       </div>
-
-      <PostList
+      {posts.length ? <PostList
         posts={currentPosts}
         currentPage={currentPage}
         postsPerPage={postsPerPage}
         totalPosts={posts.length}
         onPageChange={handlePageChange}
         onPostClick={handlePostClick}
-      />
+      /> :
+      <div className='h-20 w-full flex justify-center items-center gap-20 mt-10'>
+        작성하신 Q&A 게시글이 없습니다! <br>
+        </br>
+        지금 게시글을 작성해 보세요.
+        <img src={icon_logo} className='w-20 h-22'></img>
+      </div>}
+      
     </div>
   );
 };

--- a/src/pages/QnA/QuestionDetail.tsx
+++ b/src/pages/QnA/QuestionDetail.tsx
@@ -178,8 +178,8 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Button, message } from 'antd';
-import { StarOutlined, FormOutlined } from '@ant-design/icons';
-import { findPost, updatePost } from '../../utils/postStorage';  // updatePost 함수 추가
+import { StarOutlined, FormOutlined, DeleteOutlined } from '@ant-design/icons';
+import { findPost, updatePost, deletePost } from '../../utils/postStorage';  // updatePost 함수 추가
 import '../../App.css';
 import PostRegisterButton from '../../components/PostRegisterButton';
 import Comments from '../../components/post/Comments';
@@ -190,6 +190,7 @@ import { AnswerInterface } from '../../constants/posts';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../hoc/store';
 import Chatbot from '../../components/Chatbot';
+import { Root } from 'react-dom/client';
 
 const QuestionDetail: React.FC = () => {
   const { postId } = useParams<{ postId: string }>();
@@ -210,7 +211,6 @@ const QuestionDetail: React.FC = () => {
     const storedAnswers = localStorage.getItem('answers');
     const parsedAnswers = storedAnswers ? JSON.parse(storedAnswers) : {};
     setAnswers(parsedAnswers);
-    console.log(isAuthenticated);
 
     if (!postId) {
       message.error('질문 ID가 없습니다.');
@@ -273,6 +273,12 @@ const QuestionDetail: React.FC = () => {
     setIsChatbotVisible((prev) => !prev);
   };
 
+  const handlePostDelete = () => {
+    console.log(postId);
+    deletePost(Number(postId));
+    navigate('/qna');
+  }
+
   return (
     <div
       style={{
@@ -311,7 +317,7 @@ const QuestionDetail: React.FC = () => {
                 <span>좋아요 {post.counts.likes || 0}</span>
                 <span>스크랩 {post.counts.scraps || 0}</span>
               </div>
-              <div className='flex justify-end gap-4'>
+              <div className='flex justify-end gap-2'>
                 {!isAnswered && userRole === 'B' && (
                   <Button
                     type="primary"
@@ -320,6 +326,10 @@ const QuestionDetail: React.FC = () => {
                   >
                     답변하기
                   </Button>
+                )}
+                {(post.email === userEmail) && (
+                  <Button icon={<DeleteOutlined />}
+                  onClick={handlePostDelete}>삭제</Button>
                 )}
                 <Button icon={<StarOutlined />}>스크랩</Button>
               </div>

--- a/src/pages/QnA/QuestionRegister.tsx
+++ b/src/pages/QnA/QuestionRegister.tsx
@@ -94,6 +94,7 @@ const PostRegister: React.FC = () => {
       title,
       content,
       author: nickname || '',
+      email : userEmail,
       createdAt: new Date().toISOString(),
       answered: false,
       counts: {

--- a/src/utils/postStorage.ts
+++ b/src/utils/postStorage.ts
@@ -7,7 +7,7 @@ const getPosts = (): Post[] => {
   return posts ? JSON.parse(posts) : [];
 };
 
-const getPostsByNickname = (nickname : string) : Post[] => {
+const getPostsByEmail = (email : string) : Post[] => {
   const posts = localStorage.getItem(LOCAL_STORAGE_KEY);
   if (!posts) {
     return [];
@@ -15,7 +15,7 @@ const getPostsByNickname = (nickname : string) : Post[] => {
   const parsedPosts: Post[] = JSON.parse(posts);
   
   // nickname이 특정 값인 post만 필터링
-  return parsedPosts.filter(post => post.nickname === nickname);
+  return parsedPosts.filter(post => post.email === email);
 }
 
 const postCount = () => {
@@ -55,6 +55,19 @@ const updatePost = (post: Post) => {
   }
 };
 
+// 포스트 삭제
+const deletePost = (postId: number) => {
+  const posts = getPosts();
+  const updatedPosts = posts.filter((post) => post.id !== postId);
+
+  // 포스트가 삭제되었으면 새로 저장
+  if (posts.length !== updatedPosts.length) {
+    savePosts(updatedPosts);
+  } else {
+    console.error('Post not found');
+  }
+};
+
 // export function updatePost(post: Post) {
 //   const posts = JSON.parse(localStorage.getItem('posts') || '[]');
 //   const index = posts.findIndex((u) => u.id === post.id);
@@ -65,4 +78,4 @@ const updatePost = (post: Post) => {
 //   }
 // }
 
-export { getPosts, getPostsByNickname, savePost, findPost, updatePost, postCount };
+export { getPosts, getPostsByEmail, savePost, findPost, updatePost, postCount, deletePost };


### PR DESCRIPTION
- 사용자의 email로 게시물 조회 위해 QuestionRegister의 post 양식에 email 추가
- 작성자의 email과 현재 로그인한 사용자의 email이 일치해야 삭제 버튼이 렌더링
- Q&A 삭제시 삭제 여부를 다시 묻는 모달/알림창 필요할 듯 -> 지금은 바로 삭제 후 /qna로 navigate
- 마이페이지의 게시글에서 작성한 글 리스트 출력
- 작성한 글이 없으면 별도의 문구 출력